### PR TITLE
Fix to enable library to work on Apple Silicon

### DIFF
--- a/RNZendeskChat.podspec
+++ b/RNZendeskChat.podspec
@@ -21,5 +21,4 @@ Pod::Spec.new do |s|
   s.dependency 'ZendeskAnswerBotSDK'
   s.dependency 'ZendeskSupportSDK', '~> 6.0.0'
   s.dependency 'ZendeskChatSDK'
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zendesk-v2",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Removing the exclusion of arm64 for the simulator.
This was causing the library to return as null when running on machines with Apple Silicon.